### PR TITLE
Rustup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,4 +156,10 @@ mod tests {
         let _s1 = Semaphore::new("create_twice", 1).unwrap();
         let _s2 = Semaphore::new("create_twice", 0).unwrap();
     }
+
+    #[test]
+    fn check_send() {
+        fn send<S: Send>(_: &S) {}
+        send(&Semaphore::new("send", 1).unwrap());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,4 +162,10 @@ mod tests {
         fn send<S: Send>(_: &S) {}
         send(&Semaphore::new("send", 1).unwrap());
     }
+
+    #[test]
+    fn check_sync() {
+        fn send<S: Sync>(_: &S) {}
+        send(&Semaphore::new("sync", 1).unwrap());
+    }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -68,6 +68,7 @@ impl Semaphore {
 }
 
 unsafe impl Send for Semaphore {}
+unsafe impl Sync for Semaphore {}
 
 impl Drop for Semaphore {
     fn drop(&mut self) {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -67,6 +67,8 @@ impl Semaphore {
     }
 }
 
+unsafe impl Send for Semaphore {}
+
 impl Drop for Semaphore {
     fn drop(&mut self) {
         unsafe { libc::CloseHandle(self.handle); }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,7 +8,7 @@ use std::str;
 
 fn main() {
     let mut args = env::args();
-    if args.len() == 0 {
+    if args.len() == 1 {
         return run_test();
     }
     args.next().unwrap();
@@ -52,12 +52,7 @@ fn first_pass() {
 
 fn run_test() {
     let test_exe = env::current_exe().unwrap();
-    let mut bin = test_exe.with_file_name("test");
-    bin = match test_exe.extension() {
-        Some(v) => bin.with_extension(v),
-        None => bin,
-    };
-    let output = Command::new(bin).arg("test1").output().unwrap();
+    let output = Command::new(test_exe).arg("test1").output().unwrap();
     assert! (output.status.success());
     assert_eq! (str::from_utf8(&output.stdout).unwrap(),
 r#"Enter: test1


### PR DESCRIPTION
Actualize code for actual rust (I'm tested on rust 1.11):
- Make Semaphore implements Send trait on Windows;
- Fix `tests/test.rs` code.
